### PR TITLE
Patch the Aztec C 3.4 C preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The source for CP/M-86 doc, sources and binaries is http://www.cpm.z80.de.
 A cleaned-up distribution and kernel is available at https://github.com/tsupplis/cpm86-kernel. This distribution is working well in virtual environments, patched with all known patches, 'y2k' friendly (it contains the version of tod which sources are in this project) and AT friendly.
 
 ## Key tools for CP/M-86 development
-- aztec c compiler version 3.4/3.40a (K&R, the CP/M-86 library is provided as c86.lib)
+- aztec c compiler version 3.4/3.40a (K&R, the CP/M-86 library is provided as c86.lib), patched
 - aztec c compiler version 4.2/4.10d (Almost ANSI, the code for the CP/M-86 library (c86.lib) is patched and recompiled from 3.4 sources, as it is not part of the default compiler package. a dos 1.1 library (d11.lib) is also provided in the same manner), the documentation can be found at (https://www.aztecmuseum.ca/docs/Aztec_C_MSDOS_4.10C_Commercial_Apr88.pdf)
 - rasm86/link86,lib86 DOS version from Digital Research 
 - asm86.com  and gendef.com from Digital Research

--- a/src/fetch/aztec34
+++ b/src/fetch/aztec34
@@ -17,3 +17,11 @@ if [ ! -d aztec34/bin -o ! -f emu/cpm86.exe ];then
     cp -R az8634b/include aztec34
     rm -rf az8634b
 fi
+
+echo INF: Patching the Aztec 3.4 preprocessor ...
+ccb34="$root/share/aztec34/bin/ccb.exe"
+cc34="$root/share/aztec34/bin/cc.exe"
+if [ -f "$cc34" ] && [ ! -f "$cc34.bak" ] && \
+   [ -f "$ccb34" ] && [ ! -f "$ccb34.bak" ]; then
+    sh "$root/src/patch/patch_aztec_cpp"
+fi

--- a/src/patch/patch_aztec_cpp
+++ b/src/patch/patch_aztec_cpp
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Copyright (c) 2026 Jeffrey H. Johnson <johnsonjh.dev@gmail.com>
+# SPDX-License-Identifier: MIT-0
+# Aztec C 3.4 preprocessor patch v1.0
+
+set -eu
+
+patch_file()
+{
+  file="${1}"
+  offset="${2}"
+  data="${3}"
+  printf '%b' "${data}" \
+    | dd of="${file}" bs=1 seek="${offset}" conv=notrunc 2> /dev/null
+}
+
+patch_one()
+{
+  infile="${1}"
+  backup="${infile}.bak"
+  base=${infile##*/}
+
+  if [ ! -f "${infile}" ]; then
+    printf '%s\n' "FATAL: '${infile}' not found" >&2
+    exit 1
+  fi
+
+  if [ -e "${backup}" ]; then
+    printf '%s\n' "FATAL: '${backup}' already exists, aborting!" >&2
+    exit 1
+  fi
+
+  mv -f "${infile}" "${backup}"
+  cp -f "${backup}" "${infile}"
+
+  case ${base} in
+  cc.exe)
+    patch_file "${infile}" 86223 '\x00\x00\x00\x00\x00'
+    patch_file "${infile}" 86380 '\x00\x00\x00\x00'
+    patch_file "${infile}" 86385 '\x00\x00\x00\x00\x00\x00\x00\x00'
+    ;;
+  ccb.exe)
+    patch_file "${infile}" 43903 '\x00\x00\x00\x00\x00'
+    patch_file "${infile}" 44060 '\x00\x00\x00\x00'
+    patch_file "${infile}" 44065 '\x00\x00\x00\x00\x00\x00\x00\x00'
+    ;;
+  *)
+    printf '%s\n' "FATAL: unknown file '${infile}'" >&2
+    exit 1
+    ;;
+  esac
+
+  printf '%s\n' "Patched '${infile}'; original saved as '${backup}'"
+}
+
+patch_one "./aztec34/bin/cc.exe"
+patch_one "./aztec34/bin/ccb.exe"


### PR DESCRIPTION
* Allow redefining `const`, `volatile`, and `void` as these are not reserved keywords recognized by the Aztec C 3.4 compiler.
* Closes #8