### PR TITLE
Fix syntax error compiling functions declared void with the K&R compiler

### DIFF
--- a/src/patch/patch_aztec_cpp
+++ b/src/patch/patch_aztec_cpp
@@ -1,16 +1,27 @@
 #!/bin/sh
 # Copyright (c) 2026 Jeffrey H. Johnson <johnsonjh.dev@gmail.com>
 # SPDX-License-Identifier: MIT-0
-# Aztec C 3.4 preprocessor patch v1.0
+# Aztec C 3.4 preprocessor patch v2.0
 
 set -eu
 
-patch_file()
+patch_byte()
 {
   file="${1}"
   offset="${2}"
-  data="${3}"
-  printf '%b' "${data}" \
+  expect="${3}"
+  new="${4}"
+
+  cur=$(dd if="${file}" bs=1 skip="${offset}" count=1 2> /dev/null \
+    | od -A n -t x1 | tr -d ' \n')
+  if [ "${cur}" != "${expect}" ]; then
+    printf '%s\n' \
+      "FATAL: '${file}' at ${offset}: expected 0x${expect}, got 0x${cur}" >&2
+    printf '%s\n' \
+      "       (wrong file, wrong version, or already patched); aborting!" >&2
+    exit 1
+  fi
+  printf "\\$(printf '%03o' "0x${new}")" \
     | dd of="${file}" bs=1 seek="${offset}" conv=notrunc 2> /dev/null
 }
 
@@ -35,14 +46,10 @@ patch_one()
 
   case ${base} in
   cc.exe)
-    patch_file "${infile}" 86223 '\x00\x00\x00\x00\x00'
-    patch_file "${infile}" 86380 '\x00\x00\x00\x00'
-    patch_file "${infile}" 86385 '\x00\x00\x00\x00\x00\x00\x00\x00'
+    patch_byte "${infile}" 31043 '4b' 'e2'
     ;;
   ccb.exe)
-    patch_file "${infile}" 43903 '\x00\x00\x00\x00\x00'
-    patch_file "${infile}" 44060 '\x00\x00\x00\x00'
-    patch_file "${infile}" 44065 '\x00\x00\x00\x00\x00\x00\x00\x00'
+    patch_byte "${infile}" 20558 '24' 'af'
     ;;
   *)
     printf '%s\n' "FATAL: unknown file '${infile}'" >&2


### PR DESCRIPTION
This bug was introduced with my last patch, sorry.

The same table used for deciding if something is a reserved keyword that I patched is *also* used for ignoring `void` when declared as a function type, so one table used for two things.  So the last patch fixed one bug but introduced a new one.

This new patch has been corrected and it doesn't change the table data at all. It has also been extensively regression tested, and is actually much simpler at just two bytes changed.  It only changes ERROR 115 into a warning which isn't fatal (and is hidden by default, which is the normal behavior for Aztec C 3.4 preprocessor warnings).

The updated patch script is also more robust and makes sure it's patching the correct binary, checked by size and contents.  Uses `od` to check existing contents, still 100% POSIX-conforming invocation and works anywhere.