### PR TITLE
Fetch and build latest NASM snapshot release

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ favorite package manager.
 ### Requirements
 
 * C/C++ toolchain supporting **C99** and **C++14** (*e.g.*, [GNU GCC](https://gcc.gnu.org/) or [LLVM Clang](https://clang.llvm.org/))
+* [`curl`](https://curl.se/)
 * [CMake](https://cmake.org/)
 * [`dos2unix`](https://dos2unix.sourceforge.io/)
 * [`git`](https://git-scm.com/)
@@ -235,7 +236,7 @@ it pulls the following:
 - DR Personal Basic 1.2 (stored in `src/drtools/basic.cmd`, recovered from https://datamuseum.dk/wiki/Bits:30002879; original 1.0 at http://www.cpm.z80.de/download/pbasic86.zip)
 - masm, link, asm, exe2bin, hex2bin, Microsoft Basic 86/80 (mbasic86, mbasic85 5.29, obasic 4.51) (local copies from https://github.com/microsoft/MS-DOS and repository)
 - cmdtools — cmdinfo, bin2cmd, exe2cmd built natively from (https://github.com/tsupplis/cpm86-cmdtools)
-- nasm (https://www.nasm.us/pub/nasm/releasebuilds/3.02/nasm-3.02.tar.gz)
+- nasm (https://nasm.us/pub/nasm/snapshots/)
 - upx (https://github.com/upx/upx/releases/download/v5.2.0/upx-5.2.0-src.tar.xz)
 - emu2-cpm86, a CP/M-86 enabled fork of emu2 (https://github.com/johnsonjh/emu2-cpm86), based on the upstream emu2 project (https://github.com/dmsc/emu2)
 - tnylpo (https://gitlab.com/gbrein/tnylpo.git)

--- a/src/fetch/native_nasm
+++ b/src/fetch/native_nasm
@@ -5,9 +5,17 @@ set -e
 echo INF: Checking NASM ...
 mkdir -p "$root/archive"
 if [ ! -d "$root/archive/nasm" ];then
-    fetch_get "https://www.nasm.us/pub/nasm/releasebuilds/3.02/nasm-3.02.tar.gz"
+    devurl="https://nasm.us/pub/nasm/snapshots/"
+    cururl="$(curl -s "${devurl:?}" |
+        sed -n 's/.*href="\([^"]*\)".*/\1/p' | tr -cd '0-9\n' |
+        sort -nr | head -1)"
+    curfil="$(curl -s "${devurl:?}${cururl:?}/" |
+        sed -n "s/.*href=\"\(nasm-[^\"]*${cururl}\.tar\.gz\)\".*/\1/p" |
+        sort -nr | head -1)"
+    curdir=${curfil%.tar.gz}
+    fetch_get "https://nasm.us/pub/nasm/snapshots/${cururl:?}/${curfil:?}"
     tar zxf "$ARCHIVED_FILE" -C "$root/archive"
-    mv "$root/archive/nasm-3.02" "$root/archive/nasm"
+    mv -f "$root/archive/${curdir:?}" "$root/archive/nasm"
 fi
 if [ ! -f "$root/bin/nasm" ];then
     ncpus="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || printf '%s\n' 1)"


### PR DESCRIPTION
This fetches the latest NASM snapshot instead of the latest release.

I think it's useful as we grab master/head for other things we use - up to you.