### PR TITLE
Remove em/en dash

### DIFF
--- a/bin/drfcpm_f77
+++ b/bin/drfcpm_f77
@@ -13,7 +13,7 @@ export EMU2_PROGNAME
 "$emu2" "$share/f77.cmd" "$@" -- PATH=D:\\
 rc=$?
 
-# if .cil was produced, codegen was not called automatically — run it
+# if .cil was produced, codegen was not called automatically - run it
 src="${@##* }"
 base="${src%.*}"
 if [ $rc -eq 0 ] && [ -f "${base}.cil" ]; then

--- a/clear_tools
+++ b/clear_tools
@@ -27,7 +27,7 @@ printf 'INF: removing fetch logs ...\n'
 rm -f "$root"/fetch-*.log
 
 printf 'INF: removing archive and legacy build trees ...\n'
-# Remove legacy root-level build trees (relocated to archive/ — transitional)
+# Remove legacy root-level build trees (relocated to archive/ - transitional)
 rm -rf "$root/emu2" "$root/tnylpo" "$root/nasm" "$root/upx" "$root/cmdtools"
 rm -rf "$root/archive"/*
 rm -f  "$root/bin/bin2cmd" "$root/bin/cmdinfo" "$root/bin/exe2cmd"

--- a/fetch_tools
+++ b/fetch_tools
@@ -135,14 +135,14 @@ run_fetcher() {
         printf 'INF: [%s] ok\n' "$_name"
     else
         _rc=$?
-        printf 'ERR: [%s] FAILED (exit %s) — last output:\n' "$_name" "$_rc" >&2
+        printf 'ERR: [%s] FAILED (exit %s) - last output:\n' "$_name" "$_rc" >&2
         tail -10 "$fetch_log" | sed 's/^/    /' >&2
         printf 'ERR: full log: %s\n' "$fetch_log_name" >&2
         exit "$_rc"
     fi
 }
 
-# ── Source helpers (not logged — tiny, no output) ─────────────────────────────
+# ── Source helpers (not logged - tiny, no output) ─────────────────────────────
 . src/fetch/_archive
 mkdir -p "$root/share/pcdev"
 
@@ -180,8 +180,8 @@ find "$root/share" -type f -exec chmod a-w {} \;
 printf 'INF: [test_crossdev] starting ...\n'
 (cd "$root/examples" && sh test_crossdev) >> "$fetch_log" 2>&1 \
     && printf 'INF: [test_crossdev] ok\n' \
-    || { printf 'ERR: [test_crossdev] FAILED — see %s\n' "$fetch_log_name" >&2; exit 1; }
+    || { printf 'ERR: [test_crossdev] FAILED - see %s\n' "$fetch_log_name" >&2; exit 1; }
 (cd "$root/examples" && PATH="$root/bin:$PATH" "${MAKE:-make}" clean) >> "$fetch_log" 2>&1
 
-printf 'INF: fetch and build completed — log: %s\n' "$fetch_log_name"
+printf 'INF: fetch and build completed - log: %s\n' "$fetch_log_name"
 exit 0

--- a/src/cpmtest/Makefile
+++ b/src/cpmtest/Makefile
@@ -43,7 +43,7 @@ TESTS = \
 	tst03a01.cmd \
 	tst09801.cmd
 
-# helpers — built by 'make all' but not listed in TESTS
+# helpers - built by 'make all' but not listed in TESTS
 HELPERS = sub02f02.cmd pause.cmd
 
 all: $(TESTS) $(HELPERS)

--- a/src/cpmtest/sub02f02.a86
+++ b/src/cpmtest/sub02f02.a86
@@ -1,6 +1,6 @@
             title   'sub02f02 - fn 02Fh P_CHAIN target'
 
-; P_CHAIN support binary — chained to by tst02f01.
+; P_CHAIN support binary - chained to by tst02f01.
 ; Built by 'make all' but NOT listed in TESTS (not run directly).
 ; On arrival prints the success line and exits cleanly.
 

--- a/src/cpmtest/tst02f01.a86
+++ b/src/cpmtest/tst02f01.a86
@@ -54,7 +54,7 @@ main:
             int     BDOS
 
 ; ============================================================
-; test 02f.01: chain to sub02f02 — if this returns, chain failed
+; test 02f.01: chain to sub02f02 - if this returns, chain failed
 ; ============================================================
 t02f_01:
             mov     cx, FN_PRTSTR

--- a/src/cpmtest/tst09801.a86
+++ b/src/cpmtest/tst09801.a86
@@ -90,7 +90,7 @@ t098_01:
             mov     ax, offset pfcb_fcb
             mov     2[bx], ax       ; patch +2
 
-            ; Use BX-relative write for pfcb+2 — must set BX first
+            ; Use BX-relative write for pfcb+2 - must set BX first
             mov     bx, offset pfcb
             mov     ax, offset str1
             mov     [bx], ax        ; pfcb+0 = &str1

--- a/src/fetch/cross_polypascal
+++ b/src/fetch/cross_polypascal
@@ -38,7 +38,7 @@ if [ ! -f "$root/share/polypascpm/.finished" ]; then
         rm -f ./pp*.script
     )
 
-    # lowercase all filenames (CP/M convention — emu2 finds them case-insensitively)
+    # lowercase all filenames (CP/M convention - emu2 finds them case-insensitively)
     for f in "$tmp"/*; do
         base=$(basename "$f")
         lower=$(printf '%s\n' "$base" | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
Em/en dash usage is (generally correctly or not) instant giant red flag of a low-quality vibe-coded project to many people, who will see it and instantly disregard the project completely.